### PR TITLE
Add pre sale prices to line items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,4 @@ source 'https://rubygems.org'
 gem 'spree', github: 'spree/spree', branch: '2-4-stable'
 gem 'spree_multi_currency', github: 'spree-contrib/spree_multi_currency', branch: '2-4-stable'
 
-
 gemspec

--- a/app/models/concerns/pre_sale_prices/line_item_pre_saleable.rb
+++ b/app/models/concerns/pre_sale_prices/line_item_pre_saleable.rb
@@ -1,0 +1,29 @@
+module PreSalePrices
+  module LineItemPreSaleable
+    extend ActiveSupport::Concern
+
+    included do
+      before_validation :copy_pre_sale_price
+    end
+
+    def copy_pre_sale_price
+      if variant && !pre_sale_price_set?
+        update_pre_sale_price
+      end
+    end
+
+    def update_pre_sale_price
+      variant_pre_sale_price = variant.pre_sale_price_in(variant.currency).amount
+
+      if variant_pre_sale_price > 0
+        self.pre_sale_price = variant_pre_sale_price
+      else
+        self.pre_sale_price = nil
+      end
+    end
+
+    def pre_sale_price_set?
+      self.pre_sale_price.present? && self.pre_sale_price > 0
+    end
+  end
+end

--- a/lib/spree_pre_sale_prices/engine.rb
+++ b/lib/spree_pre_sale_prices/engine.rb
@@ -11,6 +11,7 @@ module PreSalePrices
     def self.activate
       Spree::Variant.include(::PreSalePrices::VariantPreSaleable)
       Spree::Product.include(::PreSalePrices::ProductPreSaleable)
+      Spree::LineItem.include(::PreSalePrices::LineItemPreSaleable)
       Spree::Admin::PricesController.include(::PreSalePrices::AdminPricesPreSaleable)
     end
 

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -1,9 +1,36 @@
 describe Spree::LineItem do
   context '.pre_sale_price' do
-    let(:line_item) { create(:line_item, pre_sale_price: 200.99) }
+    let(:order) { create(:order) }
+    let(:default_price) { create(:pre_sale_price, amount: 50, currency: 'USD') }
+    let(:another_price) { create(:pre_sale_price, amount: 100, currency: 'USD') }
+    let(:variant) { create(:variant, pre_sale_prices: [default_price]) }
+    let(:variant_without_pre_sale_price) { create(:variant) }
+    let(:line_item_with_pre_sale_price) do
+      line_item = create(:line_item, variant: variant,
+                         pre_sale_price: variant.pre_sale_price_in('USD'))
+    end
 
-    it 'returns the pre-sale price if one was set' do
-      expect(line_item.pre_sale_price).to eq(200.99)
+    it 'adds the pre-sale price from the variant pre-sale price when creating' do
+      line_item = order.line_items.create(quantity: 1,
+                                          variant: variant)
+      expect(line_item.pre_sale_price).to eq(50.00)
+    end
+
+    it 'does not set the pre-sale price if it has already been set' do
+      line_item = order.line_items.create(quantity: 1,
+                                          variant: variant)
+
+      variant.pre_sale_prices = [another_price]
+      line_item.variant = variant
+      line_item.save
+
+      expect(line_item.pre_sale_price).to eq(50.00)
+    end
+
+    it 'ignores the pre-sale price if the variant does not have one' do
+      line_item = order.line_items.create(quantity: 1,
+                                          variant: variant_without_pre_sale_price)
+      expect(line_item.pre_sale_price).to be_nil
     end
   end
 end


### PR DESCRIPTION
Works in much the same way as prices are added to the line item: https://github.com/spree/spree/blob/master/core/app/models/spree/line_item.rb#L16
