### PR TITLE
Fix error when a variants pre sale price has a null amount

### DIFF
--- a/app/models/concerns/pre_sale_prices/line_item_pre_saleable.rb
+++ b/app/models/concerns/pre_sale_prices/line_item_pre_saleable.rb
@@ -19,7 +19,7 @@ module PreSalePrices
     def update_pre_sale_price
       variant_pre_sale_price = variant.pre_sale_price_in(variant.currency).amount
 
-      if variant_pre_sale_price > 0
+      if variant_pre_sale_price.present? and variant_pre_sale_price > 0
         self.pre_sale_price = variant_pre_sale_price
       else
         self.pre_sale_price = nil


### PR DESCRIPTION
If a variant has a pre sale price, but it's null, an "undefined method `>' for nil:NilClass" exception is raised on this line.
